### PR TITLE
IE8 Exception Workaround

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -297,7 +297,11 @@ var select = {};
       
       if (start == 0) {
         var test1 = selection.createRange(), test2 = test1.duplicate();
-        test2.moveToElementText(container);
+        try {
+          test2.moveToElementText(container);
+        } catch(exception) {
+          return null;
+        }
         if (test1.compareEndPoints("StartToStart", test2) == 0)
           return null;
       }


### PR DESCRIPTION
Quick workaround an exception we got in IE8, there might be a better way to make it work (saw http://xopus.com/devblog/2007/incompatible-pointers.html but not exactly sure what is supposed to be unselected).

Example page that does not work in IE8 for me:

<html>  
<head>  
<title>test page</title>                                                                                                                                                                 

<script src="script/codemirror/js/codemirror.js"></script>                                                                                                                               

</head>  
<body>  
<textarea rows="0" cols="0" name="work_383" id="work_383" style="width: 700px; height: 325px; ">  
body {  
  background: red;  
  font-size: 10px;  
}  
</textarea>                                                                                                                                                                              

<script type="text/javascript">                                                                                                                                                          
window.codemirror_work_383 = CodeMirror.fromTextArea('work_383', {path: 'script/codemirror/js/',parserfile: 'parsecss.js', stylesheet: 'script/codemirror/css/csscolors.css', lineNumbers: true, readOnly: true});                                                                                                                                                               
</script>                                                                                                                                                                                

</body>  
</html>
