### PR TITLE
Parser triggers

### DIFF
--- a/js/parsehtmlmixed.js
+++ b/js/parsehtmlmixed.js
@@ -1,7 +1,4 @@
 var HTMLMixedParser = Editor.Parser = (function() {
-  if (!(CSSParser && JSParser && XMLParser))
-    throw new Error("CSS, JS, and XML parsers must be loaded for HTML mixed mode to work.");
-  XMLParser.configure({useHTMLKludges: true});
 
   // tags that trigger seperate parsers
   var triggers = {
@@ -9,8 +6,17 @@ var HTMLMixedParser = Editor.Parser = (function() {
     "style":  "CSSParser"
   };
 
+  function checkDependencies() {
+    var parsers = ['XMLParser'];
+    for (var p in triggers) parsers.push(triggers[p]);
+    for (var i in parsers) {
+      if (!window[parsers[i]]) throw new Error(parsers[i] + " parser must be loaded for HTML mixed mode to work.");
+    }
+    XMLParser.configure({useHTMLKludges: true});
+  }
 
   function parseMixed(stream) {
+    checkDependencies();
     var htmlParser = XMLParser.make(stream), localParser = null, inTag = false;
     var iter = {next: top, copy: copy};
 


### PR DESCRIPTION
Hi Marijn,

I'm trying to make parsehtmlmixed.js more generic so that you can specify which tags trigger which parsers.
Ideally I wouldn't have to write a top level parser at all, just pass parsehtmlmixed a config object.

What do you think of this patch? I'm happy to work on it if you have feedback.

cheers,
--Will

PS Nice work on the js1k :-)
