### PR TITLE
Compilation fixes

### DIFF
--- a/contrib/java/js/parsejava.js
+++ b/contrib/java/js/parsejava.js
@@ -215,7 +215,6 @@ var JavaParser = Editor.Parser = (function() {
       else if (type == "(") cont(pushlex(")"), expression, expect(")"), poplex, maybeoperator);
       else if (type == "operator") cont(expression);
       else if (type == "[") cont(pushlex("]"), commasep(expression, "]"), poplex, maybeoperator);
-      else if (type == "{") cont(pushlex("}"), commasep(objprop, "}"), poplex, maybeoperator);
     }
     // Called for places where operators, function calls, or
     // subscripts are valid. Will skip on to the next action if none

--- a/contrib/scheme/js/tokenizescheme.js
+++ b/contrib/scheme/js/tokenizescheme.js
@@ -114,26 +114,6 @@ var tokenizeScheme = (function() {
 
 
     var START = function(source, setState) {
-	var readHexNumber = function(){
-	    source.next(); // skip the 'x'
-	    source.nextWhileMatches(isHexDigit);
-	    return {type: "number", style: "scheme-number"};
-	};
-
-
-	var readNumber = function() {
-	    scanSimpleNumber();
-	    if (source.equals("-") || source.equals("+")) {
-		source.next();
-	    }
-	    scanSimpleNumber();
-	    if (source.equals("i")) {
-		source.next();
-	    }
-	    return {type: "number", style: "scheme-number"};
-	};
-
-
 	// Read a word, look it up in keywords. If not found, it is a
 	// variable, otherwise it is a keyword of the type found.
 	var readWordOrNumber = function() {

--- a/js/codemirror.js
+++ b/js/codemirror.js
@@ -328,7 +328,7 @@ var CodeMirror = (function(){
       nums.onclick = function(e) {
         var handler = self.options.onLineNumberClick;
         if (handler) {
-          var div = (e || event).target || (e || event).srcElement;
+          var div = (e || window.event).target || (e || window.event).srcElement;
           var num = div == nums ? NaN : Number(div.innerHTML);
           if (!isNaN(num)) handler(num, div);
         }

--- a/js/editor.js
+++ b/js/editor.js
@@ -420,7 +420,8 @@ var Editor = (function(){
         // body of the document to focus it in IE, making focusing
         // hard when the document is small.
         if (internetExplorer && options.height != "dynamic")
-          document.body.style.minHeight = (frameElement.clientHeight - 2 * document.body.offsetTop - 5) + "px";
+          document.body.style.minHeight = (
+            window.frameElement.clientHeight - 2 * document.body.offsetTop - 5) + "px";
 
         document.documentElement.style.borderWidth = "0";
         if (!options.textWrapping)


### PR DESCRIPTION
Here are some fixes I found when running closure-compiler in the mode that treats undefined variables as errors. One's an actual runtime error in the Java parser; the rest are just for Closure's benefit.
