### PR TITLE
Remove bold and italic from all the css files

### DIFF
--- a/contrib/java/css/javacolors.css
+++ b/contrib/java/css/javacolors.css
@@ -6,7 +6,7 @@ html {
 .editbox {
   margin: .4em;
   padding: 0;
-  font-family: monospace;
+  font-family: Monaco, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console', monospace;
   font-size: 10pt;
   color: black;
 }
@@ -29,7 +29,6 @@ span.java-operator {
 
 span.java-keyword {
   color: #7f0055;
-  font-weight:bold;
 }
 
 span.java-atom {
@@ -51,7 +50,6 @@ span.java-comment {
 
 span.javadoc-comment {
   color: #3e5797;
-  font-weight:bold;
 }
 
 span.java-string {
@@ -61,4 +59,3 @@ span.java-string {
 span.java-annotation{
   color: gray;	
 }
-

--- a/contrib/lua/css/luacolors.css
+++ b/contrib/lua/css/luacolors.css
@@ -23,7 +23,6 @@ span.lua-comment {
 }
 
 span.lua-keyword {
-  font-weight: bold;
   color: blue;
 }
 
@@ -32,11 +31,9 @@ span.lua-string {
 }
 
 span.lua-stdfunc {
-  font-weight: bold;
   color: #077;
 }
 span.lua-customfunc {
-  font-weight: bold;
   color: #0AA;
 }
 
@@ -57,7 +54,3 @@ span.lua-error {
   color: #FFF;
   background-color: #F00;
 }
-
-
-
-

--- a/contrib/php/css/phpcolors.css
+++ b/contrib/php/css/phpcolors.css
@@ -36,7 +36,6 @@ span.php-punctuation {
 
 span.php-keyword {
   color: #770088;
-  font-weight: bold;
 }
 
 span.php-operator {
@@ -46,19 +45,16 @@ span.php-operator {
 /* __FILE__ etc.; http://php.net/manual/en/reserved.php */
 span.php-compile-time-constant {
   color: #776088;
-  font-weight: bold;
 }
 
 /* output of get_defined_constants(). Differs from http://php.net/manual/en/reserved.constants.php */
 span.php-predefined-constant {
   color: darkgreen;
-  font-weight: bold;
 }
 
 /* PHP reserved "language constructs"... echo() etc.; http://php.net/manual/en/reserved.php */
 span.php-reserved-language-construct {
   color: green;
-  font-weight: bold;
 }
 
 /* PHP built-in functions: glob(), chr() etc.; output of get_defined_functions()["internal"] */
@@ -82,7 +78,6 @@ span.php-t_string {
 
 span.php-variable {
   color: black;
-  font-weight: bold;
 }
 
 
@@ -102,7 +97,6 @@ span.php-string-single-quoted {
 /* double quoted strings allow interpolation */
 span.php-string-double-quoted {
   color: #AA2222;
-  font-weight: bold;
 }
 
 span.syntax-error {

--- a/contrib/python/css/pythoncolors.css
+++ b/contrib/python/css/pythoncolors.css
@@ -5,7 +5,7 @@ html {
 .editbox {
   padding: .4em;
   margin: 0;
-  font-family: monospace;
+  font-family: Courier New, monospace;
   font-size: 10pt;
   line-height: 1.1em;
   color: black;
@@ -34,7 +34,6 @@ span.py-error {
 
 span.py-keyword {
   color: #770088;
-  font-weight: bold;
 }
 
 span.py-literal {

--- a/contrib/scheme/css/schemecolors.css
+++ b/contrib/scheme/css/schemecolors.css
@@ -10,7 +10,7 @@ html {
   height: 100%;
   margin: 0pt;
   padding: 0;
-  font-family: monospace;
+  font-family: Lucida Console, monospace;
   font-size: 10pt;
   color: black;
 }
@@ -36,10 +36,8 @@ span.scheme-rparen      {color: black;}
 span.scheme-comment     { color: orange; }
 
 span.good-matching-paren { 
-    font-weight: bold;
     color: #3399FF;  
 }
 span.bad-matching-paren {
-    font-weight: bold;
     color: red;
 }

--- a/contrib/xquery/css/xqcolors-dark.css
+++ b/contrib/xquery/css/xqcolors-dark.css
@@ -15,27 +15,22 @@ span.word {
 
 span.xqueryKeyword {
   color: #ffbd40; 
-  /* font-weight: bold; */
 }
 
 span.xqueryComment {
   color: #CDCDCD;
-  font-style:italic;
 }
 
 span.xqueryModifier {
 color:#6c8cd5;
-  font-weight: bold;
 }
 
 span.xqueryType {
   color:#6c8cd5;
-  font-weight: bold;
 }
 
 span.xqueryAtom {
   color:#6c8cd5;
-  font-weight: bold;  
 }
 
 span.xqueryString {
@@ -89,5 +84,4 @@ span.xml-attribute {
 
 span.xml-attribute-value {
     color: #FFF700;
-    font-style:italic;
 }

--- a/contrib/xquery/css/xqcolors.css
+++ b/contrib/xquery/css/xqcolors.css
@@ -31,27 +31,22 @@ span.word {
 
 span.xqueryKeyword {
   color: red; /* #1240AB; */
-  /* font-weight: bold; */
 }
 
 span.xqueryComment {
   color: gray;
-  font-style: italic;
 }
 
 span.xqueryModifier {
   color: rgb(0,102,153);
-  font-weight: bold;
 }
 
 span.xqueryType {
   color: purple;
-  font-weight: bold;
 }
 
 span.xqueryAtom {
   color: rgb(0,102,153);
-  font-weight: bold;  
 }
 
 span.xqueryString {
@@ -72,7 +67,6 @@ span.xqueryVariable {
 
 span.xqueryFunction {
     color: #1240AB;     
-    /* font-weight:bold; */ 
 }
 
 
@@ -90,10 +84,8 @@ span.xml-tagname {
 
 span.xml-attribute {
     color: purple;
-    font-style:italic;
 }
 
 span.xml-attribute-value {
     color: purple;
-    font-style:italic;
 }

--- a/contrib/xquery/css/xqcolors2.css
+++ b/contrib/xquery/css/xqcolors2.css
@@ -31,7 +31,6 @@ span.word {
 
 span.xqueryKeyword {
   color: blue; 
-  /* font-weight: bold; */
 }
 
 span.xqueryComment {
@@ -40,17 +39,14 @@ span.xqueryComment {
 
 span.xqueryModifier {
   color: rgb(0,102,153);
-  font-weight: bold;
 }
 
 span.xqueryType {
   color: rgb(0,135,255);
-  font-weight: bold;
 }
 
 span.xqueryAtom {
   color: rgb(0,102,153);
-  font-weight: bold;  
 }
 
 span.xqueryString {
@@ -87,10 +83,8 @@ span.xml-tagname {
 
 span.xml-attribute {
     color: purple;
-    font-style:italic;
 }
 
 span.xml-attribute-value {
     color: purple;
-    font-style:italic;
 }


### PR DESCRIPTION
The notable font with wide bold characters is Lucida Console, the programmer's font that comes with recent versions of Windows.
